### PR TITLE
Lowercase emphasis attributes

### DIFF
--- a/doc_source/supported-ssml.md
+++ b/doc_source/supported-ssml.md
@@ -94,11 +94,11 @@ This tag emphasizes the tagged words or phrases\. Emphasizing text changes the r
 
 Three `level` options are available:
 
-+ `Strong`: Increases the volume and slows down speaking rate so the speech is louder and slower\.
++ `strong`: Increases the volume and slows down speaking rate so the speech is louder and slower\.
 
-+ `Moderate`: Increases the volume and slows down the speaking rate, but less so than when set to `strong`\. This is the default and is used if no level is provided\.
++ `moderate`: Increases the volume and slows down the speaking rate, but less so than when set to `strong`\. This is the default and is used if no level is provided\.
 
-+ `Reduced`: Decrease the volume and speed up the speaking rate\. The speech is softer and faster\.
++ `reduced`: Decrease the volume and speed up the speaking rate\. The speech is softer and faster\.
 
 **Note**  
 The normal speaking rate and volume for a given voice will fall between the `moderate` and `reduced` levels\.


### PR DESCRIPTION
This makes the documentation consistent with the rest of the documented attributes and prevents SSML errors when copying attributes from the documentation; attributes must be lowercased.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
